### PR TITLE
Batch widget-layout updates, lazy-load widget definitions, integrations context, and drag/drop optimizations

### DIFF
--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,4 +1,4 @@
-import { Account, deleteAccount, getGithubAccount, getGoogleAccount, getNotionAccount, updateAccount } from "@/database"
+import { deleteAccount, getAccountsFromUser, updateAccount } from "@/database"
 import { auth } from "@/lib/auth"
 import { deleteAccountSchema, updateAccountSchema } from "@/lib/validations"
 import { headers } from "next/headers"
@@ -13,10 +13,7 @@ export async function GET(req: Request) {
         if (!session) return new NextResponse("Unauthorized", { status: 401 })
         const userId = session.user.id
 
-        const accounts: Account[] = []
-        accounts.push((await getGoogleAccount(userId))[0])
-        accounts.push((await getGithubAccount(userId))[0])
-        accounts.push((await getNotionAccount(userId))[0])
+        const accounts = await getAccountsFromUser(userId)
 
         return NextResponse.json(accounts, { status: 200 })
     } catch {

--- a/src/app/api/widgets/layout/route.ts
+++ b/src/app/api/widgets/layout/route.ts
@@ -1,0 +1,43 @@
+import { getWidgetFromId, updateWidgetsLayout } from "@/database"
+import { auth } from "@/lib/auth"
+import { updateWidgetsLayoutSchema } from "@/lib/validations"
+import { headers } from "next/headers"
+import { NextResponse } from "next/server"
+
+export async function PATCH(req: Request) {
+    try {
+        const session = await auth.api.getSession({
+            headers: await headers()
+        })
+
+        if (!session) return new NextResponse("Unauthorized", { status: 401 })
+        const userId = session.user.id
+
+        const body = await req.json()
+        const validationResult = updateWidgetsLayoutSchema.safeParse(body)
+
+        if (!validationResult.success) {
+            return NextResponse.json("Invalid request body", { status: 400 })
+        }
+
+        const { widgets } = validationResult.data
+        if (widgets.length === 0) return NextResponse.json([], { status: 200 })
+
+        const existingWidgets = await Promise.all(widgets.map((widget) => getWidgetFromId(widget.id)))
+        const flattenedWidgets = existingWidgets.flat()
+
+        if (flattenedWidgets.length !== widgets.length) {
+            return NextResponse.json({ error: "Widget not found" }, { status: 404 })
+        }
+
+        if (flattenedWidgets.some((widget) => widget.userId !== userId)) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+        }
+
+        const updatedWidgets = await updateWidgetsLayout(widgets)
+
+        return NextResponse.json(updatedWidgets, { status: 200 })
+    } catch {
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 })
+    }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,8 +9,9 @@ import { toast } from "@/components/ui/Toast"
 import type { Widget } from "@/database"
 import { useDashboards } from "@/hooks/data/useDashboards"
 import { useSettings } from "@/hooks/data/useSettings"
+import { IntegrationsProvider, useIntegrations } from "@/hooks/data/useIntegrations"
 import { useWidgets } from "@/hooks/data/useWidgets"
-import { useResponsiveLayout } from "@/hooks/media/useResponsiveLayout"
+import { useBreakpoint } from "@/hooks/media/useBreakpoint"
 import { authClient } from "@/lib/auth-client"
 import { cn } from "@/lib/utils"
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -23,6 +24,7 @@ function DashboardContent() {
     const {data: session, isPending: sessionLoading} = authClient.useSession()
     const {settings, isLoading: settingsLoading, updateSettings} = useSettings(session?.user.id)
     const {dashboards, currentDashboard, isLoading: dashboardsLoading, addDashboard, addDashboardStatus,setSelectedDashboard} = useDashboards(session?.user.id, settings)
+    const integrations = useIntegrations(session?.user.id)
     const {widgets, isLoading: widgetsLoading, isReady: widgetsReady, removeWidget, saveWidgetsLayout, updateWidget, updateWidgetPosition, setWidgets} = useWidgets(session?.user.id)
 
     const [activeWidget, setActiveWidget] = useState<Widget | null>(null)
@@ -39,7 +41,8 @@ function DashboardContent() {
     const widgetsToRemoveIds = useMemo(() => new Set(widgetsToRemove.map((widget) => widget.id)), [widgetsToRemove])
     const visibleWidgets = useMemo(() => currentWidgets.filter((widget) => !widgetsToRemoveIds.has(widget.id)), [currentWidgets, widgetsToRemoveIds])
 
-    const {isDesktop} = useResponsiveLayout(visibleWidgets, isFullscreen)
+    const {breakpoint} = useBreakpoint()
+    const isDesktop = breakpoint === "desktop"
 
     const cachedWidgetsRef = useRef<Widget[] | null>(null)
     const currentWidgetsRef = useRef<Widget[]>([])
@@ -104,7 +107,19 @@ function DashboardContent() {
             if (widgetsToRemove.length > 0) {
                 await Promise.all(widgetsToRemove.map((widget) => removeWidget(widget.id)))
             }
-            await saveWidgetsLayout()
+            const removedWidgetIds = new Set(widgetsToRemove.map((widget) => widget.id))
+            const cachedWidgets = cachedWidgetsRef.current ?? []
+            const cachedById = new Map(cachedWidgets.map((widget) => [widget.id, widget]))
+            const dirtyWidgets = widgets.filter((widget) => {
+                if (removedWidgetIds.has(widget.id)) return false
+                const cached = cachedById.get(widget.id)
+                return !cached
+                    || cached.width !== widget.width
+                    || cached.height !== widget.height
+                    || cached.positionX !== widget.positionX
+                    || cached.positionY !== widget.positionY
+            })
+            await saveWidgetsLayout(dirtyWidgets)
             toast.success("Successfully updated your layout.")
         } catch (error) {
             console.log(error)
@@ -115,7 +130,7 @@ function DashboardContent() {
             setWidgetsToRemove([])
             cachedWidgetsRef.current = null
         }
-    }, [removeWidget, saveWidgetsLayout, widgetsToRemove])
+    }, [removeWidget, saveWidgetsLayout, widgets, widgetsToRemove])
 
     const handleEditModeCancel = useCallback(() => {
         if (cachedWidgetsRef.current) setWidgets(cachedWidgetsRef.current)
@@ -144,6 +159,7 @@ function DashboardContent() {
     ), [sessionLoading, dashboardsLoading, widgetsLoading, settingsLoading])
 
     return (
+        <IntegrationsProvider value={integrations}>
         <div className={cn("flex flex-col w-full h-full", isDesktop && "max-h-screen max-w-screen overflow-hidden")}>
             {mounted ? (
                 <Header
@@ -209,6 +225,7 @@ function DashboardContent() {
                 />
             </Suspense>
         </div>
+        </IntegrationsProvider>
     )
 }
 

--- a/src/components/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer.tsx
@@ -8,7 +8,6 @@ import {getIntegrationByProvider, useIntegrations} from "@/hooks/data/useIntegra
 import {WidgetError} from "@/components/widgets/base/WidgetError"
 import {ErrorBoundary} from "react-error-boundary"
 import {Skeleton} from "@/components/ui/Skeleton"
-import { authClient } from "@/lib/auth-client"
 
 const areWidgetsEqual = (a: BaseWidget, b: BaseWidget): boolean => (
     a === b
@@ -35,8 +34,7 @@ const WidgetSkeleton = () => (
 )
 
 const WidgetRendererComponent: React.FC<WidgetRuntimeProps> = ({widget, editMode, isDragging, onWidgetDelete, onWidgetUpdate}) => {
-    const { data: session, isPending: sessionPending } = authClient.useSession()
-    const {integrations, isLoading: isLoadingIntegrations, handleIntegrate} = useIntegrations(session?.user.id)
+    const {integrations, isLoading: isLoadingIntegrations, handleIntegrate} = useIntegrations(widget.userId)
 
     const definition = useMemo(() => getWidgetDefinition(widget.widgetType), [widget.widgetType])
     const {Component, defaultConfig, name, integration: requiredIntegration, sizes: defaultSizes} = definition
@@ -70,7 +68,7 @@ const WidgetRendererComponent: React.FC<WidgetRuntimeProps> = ({widget, editMode
         })
     }, [defaultConfig, onWidgetUpdate, widget])
 
-    if (sessionPending || isLoadingIntegrations) {
+    if (isLoadingIntegrations) {
         return (
             <WidgetContainer
                 widget={widget}

--- a/src/database.ts
+++ b/src/database.ts
@@ -38,6 +38,28 @@ export const updateWidget = async (id: string, data: Partial<WidgetInsert>) => {
         .returning()
 }
 
+export type WidgetLayoutUpdate = Pick<WidgetInsert, "height" | "width" | "positionX" | "positionY"> & { id: string }
+
+export const updateWidgetsLayout = async (updates: WidgetLayoutUpdate[]) => {
+    const now = new Date()
+
+    return db.transaction(async (tx) => {
+        const updatedWidgets = []
+
+        for (const { id, ...data } of updates) {
+            const updated = await tx
+                .update(widget)
+                .set({...data, updatedAt: now})
+                .where(eq(widget.id, id))
+                .returning()
+
+            updatedWidgets.push(...updated)
+        }
+
+        return updatedWidgets
+    })
+}
+
 export const deleteWidget = async (id: string) => {
     return db
         .delete(widget)
@@ -200,6 +222,13 @@ export const getNotionAccount = async (userId: string): Promise<Account[]> => {
             eq(account.userId, userId),
             eq(account.providerId, "notion")
         ))
+}
+
+export const getAccountsFromUser = async (userId: string): Promise<Account[]> => {
+    return db
+        .select()
+        .from(account)
+        .where(eq(account.userId, userId))
 }
 
 export const updateAccount = async (userId: string, provider: string, data: Partial<AccountInsert>) => {

--- a/src/hooks/data/useIntegrations.tsx
+++ b/src/hooks/data/useIntegrations.tsx
@@ -1,10 +1,13 @@
+"use client"
+
 import {useMutation, useQuery, useQueryClient} from "@tanstack/react-query"
 import type {Account} from "@/database"
 import {authClient} from "@/lib/auth-client"
 import {toast} from "@/components/ui/Toast"
 import { queryOptions } from "@/lib/queryOptions"
+import { createContext, ReactNode, useCallback, useContext, useMemo } from "react"
 
-interface Integration {
+export interface Integration {
     id: string
     accountId: string
     userId: string
@@ -72,18 +75,38 @@ async function updateIntegrationRequest({provider, userId, data}: UpdateIntegrat
     return result[0]
 }
 
+type IntegrationsValue = {
+    userId: string | undefined
+    integrations: Integration[]
+    isLoading: boolean
+    handleIntegrate: (provider: string, callback?: boolean) => Promise<void>
+    refetchIntegrations: () => Promise<unknown>
+    removeIntegration: (provider: string) => Promise<void>
+    removeIntegrationStatus: string
+    updateIntegration: (args: UpdateIntegrationArgs) => Promise<Integration>
+    updateIntegrationStatus: string
+}
+
+const IntegrationsContext = createContext<IntegrationsValue | null>(null)
+
+export function IntegrationsProvider({children, value}: {children: ReactNode; value: IntegrationsValue}) {
+    return <IntegrationsContext.Provider value={value}>{children}</IntegrationsContext.Provider>
+}
+
 export function useIntegrations(userId: string | undefined) {
+    const context = useContext(IntegrationsContext)
     const queryClient = useQueryClient()
+    const hasScopedContext = context?.userId === userId
 
     const integrationsQuery = useQuery<Integration[], Error>(queryOptions({
         queryKey: INTEGRATIONS_QUERY_KEY(userId),
         queryFn: () => fetchIntegrations(userId!),
-        enabled: Boolean(userId),
+        enabled: Boolean(userId) && !hasScopedContext,
     }))
 
     const { refetch: refetchIntegrations, data, isLoading } = integrationsQuery
 
-    const isLoadingIntegrations = isLoading && !data
+    const isLoadingIntegrations = hasScopedContext ? context.isLoading : isLoading && !data
 
     const removeIntegrationMutation = useMutation({
         mutationFn: unlinkIntegration,
@@ -108,21 +131,22 @@ export function useIntegrations(userId: string | undefined) {
         }
     })
 
-    const handleIntegrate = async (provider: string, callback = true) => {
-        const data = await authClient.signIn.social({
+    const handleIntegrate = useCallback(async (provider: string, callback = true): Promise<void> => {
+        await authClient.signIn.social({
             provider,
             callbackURL: callback ? CALLBACK_URL : undefined,
         }, {
-            onRequest: (ctx) => {
+            onRequest: () => {
                 void refetchIntegrations()
             },
-            onError: (ctx) => {
+            onError: () => {
                 toast.error("Something went wrong.")
             }
         })
-    }
+    }, [refetchIntegrations])
 
-    return {
+    const fallbackValue = useMemo(() => ({
+        userId,
         integrations: data ?? [],
         isLoading: isLoadingIntegrations,
         handleIntegrate,
@@ -131,7 +155,17 @@ export function useIntegrations(userId: string | undefined) {
         removeIntegrationStatus: removeIntegrationMutation.status,
         updateIntegration: (args: UpdateIntegrationArgs) => updateIntegrationMutation.mutateAsync(args),
         updateIntegrationStatus: updateIntegrationMutation.status,
-    }
+    }), [
+        data,
+        handleIntegrate,
+        isLoadingIntegrations,
+        refetchIntegrations,
+        removeIntegrationMutation,
+        updateIntegrationMutation,
+        userId,
+    ])
+
+    return hasScopedContext ? context : fallbackValue
 }
 
 export function getIntegrationByProvider(integrations: Integration[], provider: string | undefined) {

--- a/src/hooks/data/useWidgets.ts
+++ b/src/hooks/data/useWidgets.ts
@@ -47,16 +47,18 @@ async function updateWidgetRequest(widget: Widget): Promise<Widget> {
 
 type WidgetLayoutUpdate = Pick<Widget, "id" | "width" | "height" | "positionX" | "positionY">
 
-async function updateWidgetLayoutRequest(widget: WidgetLayoutUpdate): Promise<void> {
-    const response = await fetch("/api/widgets", {
-        method: "PUT",
+async function updateWidgetsLayoutRequest(widgets: WidgetLayoutUpdate[]): Promise<Widget[]> {
+    const response = await fetch("/api/widgets/layout", {
+        method: "PATCH",
         headers: {"Content-Type": "application/json"},
-        body: JSON.stringify(widget)
+        body: JSON.stringify({widgets})
     })
 
     if (!response.ok) {
-        throw new Error(`Error saving widget ${widget.id}`)
+        throw new Error("Error saving widget layout")
     }
+
+    return response.json()
 }
 
 async function deleteWidgetRequest(id: string): Promise<void> {
@@ -94,7 +96,7 @@ function findNextAvailablePosition(widgets: Widget[] | undefined, newWidgetWidth
         .fill(false)
         .map(() => Array(gridSize).fill(false))
 
-    relevant.map((widget) => {
+    for (const widget of relevant) {
         for (let i = 0; i < widget.width; i++) {
             for (let j = 0; j < widget.height; j++) {
                 const x = widget.positionX + i
@@ -105,7 +107,7 @@ function findNextAvailablePosition(widgets: Widget[] | undefined, newWidgetWidth
                 }
             }
         }
-    })
+    }
 
     for (let y = 0; y < gridSize; y++) {
         for (let x = 0; x < gridSize; x++) {
@@ -215,18 +217,25 @@ export function useWidgets(userId: string | undefined) {
     })
 
     const saveWidgetsLayoutMutation = useMutation({
-        mutationFn: async () => {
-            const widgets = queryClient.getQueryData<Widget[]>(WIDGETS_QUERY_KEY(userId)) ?? []
+        mutationFn: async (widgetsToSave?: Widget[]) => {
+            const widgets = widgetsToSave ?? queryClient.getQueryData<Widget[]>(WIDGETS_QUERY_KEY(userId)) ?? []
+            if (widgets.length === 0) return []
 
-            await Promise.all(
-                widgets.map((widget) => updateWidgetLayoutRequest({
-                    id: widget.id,
-                    width: widget.width,
-                    height: widget.height,
-                    positionX: widget.positionX,
-                    positionY: widget.positionY
-                }))
-            )
+            return updateWidgetsLayoutRequest(widgets.map((widget) => ({
+                id: widget.id,
+                width: widget.width,
+                height: widget.height,
+                positionX: widget.positionX,
+                positionY: widget.positionY
+            })))
+        },
+        onSuccess: (updatedWidgets) => {
+            if (!updatedWidgets || updatedWidgets.length === 0) return
+            queryClient.setQueryData(WIDGETS_QUERY_KEY(userId), (previous: Widget[] | undefined) => {
+                if (!previous) return previous
+                const updatedById = new Map(updatedWidgets.map((widget) => [widget.id, widget]))
+                return previous.map((widget) => updatedById.get(widget.id) ?? widget)
+            })
         }
     })
 
@@ -262,7 +271,7 @@ export function useWidgets(userId: string | undefined) {
         addWidget: useCallback((widget: WidgetInsert) => addWidgetMutation.mutateAsync(widget), [addWidgetMutation]),
         updateWidget: useCallback((widget: Widget) => refreshWidgetMutation.mutateAsync(widget), [refreshWidgetMutation]),
         removeWidget: useCallback((id: string) => removeWidgetMutation.mutateAsync(id), [removeWidgetMutation]),
-        saveWidgetsLayout: useCallback(() => saveWidgetsLayoutMutation.mutateAsync(), [saveWidgetsLayoutMutation]),
+        saveWidgetsLayout: useCallback((widgetsToSave?: Widget[]) => saveWidgetsLayoutMutation.mutateAsync(widgetsToSave), [saveWidgetsLayoutMutation]),
         updateWidgetPosition,
         getWidget,
         setWidgets,

--- a/src/hooks/media/useResponsiveLayout.ts
+++ b/src/hooks/media/useResponsiveLayout.ts
@@ -9,7 +9,7 @@ const layoutCache = new Map<string, Widget[]>()
 
 const getCacheKey = (widgets: Widget[], breakpoint: Breakpoint, isFullscreen?: boolean): string => {
     const widgetIds = widgets
-        .map((w) => `${w.id}-${w.positionX}-${w.positionY}-${w.width}-${w.height}-${w.updatedAt ?? ""}-${JSON.stringify(w.config ?? null)}`)
+        .map((w) => `${w.id}-${w.positionX}-${w.positionY}-${w.width}-${w.height}-${w.updatedAt ?? ""}`)
         .join(",")
     return `${breakpoint}-${isFullscreen}-${widgetIds}`
 }

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -8,20 +8,20 @@ import {
     useSensor,
     useSensors
 } from "@dnd-kit/core"
-import { useCallback, useMemo } from "react"
+import { useCallback, useEffect, useMemo, useRef } from "react"
 
 function findFreePosition(relevantWidgets: Widget[], width: number, height: number, excludeId?: string, excludePosition?: { x: number, y: number, width: number, height: number }) {
     const occupiedCells: Record<string, boolean> = {}
 
-    relevantWidgets.map((widget) => {
-        if (excludeId && widget.id === excludeId) return
+    for (const widget of relevantWidgets) {
+        if (excludeId && widget.id === excludeId) continue
 
         for (let i = 0; i < widget.width; i++) {
             for (let j = 0; j < widget.height; j++) {
                 occupiedCells[`${widget.positionX + i},${widget.positionY + j}`] = true
             }
         }
-    })
+    }
 
     if (excludePosition) {
         for (let i = 0; i < excludePosition.width; i++) {
@@ -51,11 +51,37 @@ function findFreePosition(relevantWidgets: Widget[], width: number, height: numb
 }
 
 export const useDragAndDrop = (editMode: boolean, widgets: Widget[] | undefined, currentDashboardId: string | null, updateWidgetPosition: (id: string, x: number, y: number) => void, setActiveWidget: (widget: Widget | null) => void) => {
+    const pendingPositionUpdatesRef = useRef(new Map<string, { x: number; y: number }>())
+    const animationFrameRef = useRef<number | null>(null)
     const relevantWidgets = useMemo(() => {
         if (!widgets || !currentDashboardId) return []
         const alreadyScoped = widgets.every((widget) => widget.dashboardId === currentDashboardId)
         return alreadyScoped ? widgets : widgets.filter((widget) => widget.dashboardId === currentDashboardId)
     }, [widgets, currentDashboardId])
+
+    const flushPositionUpdates = useCallback(() => {
+        animationFrameRef.current = null
+        const updates = Array.from(pendingPositionUpdatesRef.current.entries())
+        pendingPositionUpdatesRef.current.clear()
+
+        for (const [id, position] of updates) {
+            updateWidgetPosition(id, position.x, position.y)
+        }
+    }, [updateWidgetPosition])
+
+    const scheduleWidgetPositionUpdate = useCallback((id: string, x: number, y: number) => {
+        pendingPositionUpdatesRef.current.set(id, {x, y})
+
+        if (animationFrameRef.current === null) {
+            animationFrameRef.current = window.requestAnimationFrame(flushPositionUpdates)
+        }
+    }, [flushPositionUpdates])
+
+    useEffect(() => () => {
+        if (animationFrameRef.current !== null) {
+            window.cancelAnimationFrame(animationFrameRef.current)
+        }
+    }, [])
 
     const sensors = useSensors(
         useSensor(MouseSensor, {
@@ -88,7 +114,7 @@ export const useDragAndDrop = (editMode: boolean, widgets: Widget[] | undefined,
         const conflictingWidgets = getConflictingWidgets(newWidget, x, y, excludeId)
         const movedWidgets: Array<{ id: string; x: number; y: number; width: number; height: number }> = []
 
-        conflictingWidgets.map((widget) => {
+        for (const widget of conflictingWidgets) {
             const updatedWidgets = relevantWidgets.map(w => {
                 const moved = movedWidgets.find(m => m.id === w.id)
                 return moved ? { ...w, positionX: moved.x, positionY: moved.y } : w
@@ -101,10 +127,10 @@ export const useDragAndDrop = (editMode: boolean, widgets: Widget[] | undefined,
                 height: newWidget.height,
             })
 
-            updateWidgetPosition(widget.id, freePosition.x, freePosition.y)
+            scheduleWidgetPositionUpdate(widget.id, freePosition.x, freePosition.y)
             movedWidgets.push({ id: widget.id, x: freePosition.x, y: freePosition.y, width: widget.width, height: widget.height })
-        })
-    }, [getConflictingWidgets, updateWidgetPosition, relevantWidgets])
+        }
+    }, [getConflictingWidgets, scheduleWidgetPositionUpdate, relevantWidgets])
 
     const handleDragStart = useCallback((event: DragStartEvent) => {
         if (!editMode) return
@@ -130,11 +156,11 @@ export const useDragAndDrop = (editMode: boolean, widgets: Widget[] | undefined,
 
         if (over && active.id !== over.id) {
             const { x, y } = over.data.current as { x: number; y: number }
-            updateWidgetPosition(active.id as string, x, y)
+            scheduleWidgetPositionUpdate(active.id as string, x, y)
         }
 
         setActiveWidget(null)
-    }, [editMode, updateWidgetPosition, setActiveWidget])
+    }, [editMode, scheduleWidgetPositionUpdate, setActiveWidget])
 
     return { sensors, handleDragStart, handleDragOver, handleDragEnd }
 }

--- a/src/hooks/useGrid.ts
+++ b/src/hooks/useGrid.ts
@@ -1,67 +1,59 @@
 import { Widget } from "@/database"
-import { useEffect, useMemo, useState } from "react"
+import { useMemo } from "react"
+
+type GridCell = {
+    x: number
+    y: number
+    width: number
+    height: number
+    isDroppable: boolean
+}
+
+const GRID_SIZE = 4
 
 export const useGrid = (activeWidget: Widget | null, widgets: Widget[] | undefined) => {
-    const filteredWidgets = useMemo(() => widgets ?? [], [widgets])
+    return useMemo<GridCell[]>(() => {
+        if (!activeWidget) return []
 
-    const [gridCells, setGridCells] = useState<{
-        x: number,
-        y: number,
-        width: number,
-        height: number,
-        isDroppable: boolean
-    }[]>([])
+        const occupiedCells = new Set<string>()
+        const filteredWidgets = widgets ?? []
 
-    const getOccupiedCells = () => {
-        const occupiedCells: Record<string, boolean> = {}
+        for (const widget of filteredWidgets) {
+            if (widget.id === activeWidget.id) continue
 
-        filteredWidgets?.map((widget) => {
-            if (activeWidget && widget.id === activeWidget.id) return
-            const { width, height, positionX, positionY } = widget
-
-            for (let i = 0; i < width; i++) {
-                for (let j = 0; j < height; j++) {
-                    occupiedCells[`${positionX + i},${positionY + j}`] = true
+            for (let i = 0; i < widget.width; i++) {
+                for (let j = 0; j < widget.height; j++) {
+                    occupiedCells.add(`${widget.positionX + i},${widget.positionY + j}`)
                 }
             }
-        })
+        }
 
-        return occupiedCells
-    }
+        const canPlaceWidget = (x: number, y: number) => {
+            if (x + activeWidget.width > GRID_SIZE || y + activeWidget.height > GRID_SIZE) return false
 
-    const canPlaceWidget = (widget: { width: number; height: number }, x: number, y: number) => {
-        const { width, height } = widget
-        const occupiedCells = getOccupiedCells()
-
-        if (x + width > 4 || y + height > 4) return false
-
-        for (let i = 0; i < width; i++) {
-            for (let j = 0; j < height; j++) {
-                const cellKey = `${x + i},${y + j}`
-                if (occupiedCells[cellKey]) return false
+            for (let i = 0; i < activeWidget.width; i++) {
+                for (let j = 0; j < activeWidget.height; j++) {
+                    if (occupiedCells.has(`${x + i},${y + j}`)) return false
+                }
             }
-        }
-        return true
-    }
 
-    useEffect(() => {
-        if (!activeWidget) {
-            setGridCells([])
-            return
+            return true
         }
 
-        const cells = []
-        const { width, height } = activeWidget
+        const cells: GridCell[] = []
 
-        for (let y = 0; y <= 4 - height; y++) {
-            for (let x = 0; x <= 4 - width; x++) {
-                const isDroppable = canPlaceWidget(activeWidget, x, y)
-                cells.push({ x, y, width, height, isDroppable })
+        for (let y = 0; y <= GRID_SIZE - activeWidget.height; y++) {
+            for (let x = 0; x <= GRID_SIZE - activeWidget.width; x++) {
+                cells.push({
+                    x,
+                    y,
+                    width: activeWidget.width,
+                    height: activeWidget.height,
+                    isDroppable: canPlaceWidget(x, y),
+                })
             }
         }
 
-        setGridCells(cells)
-    }, [activeWidget, filteredWidgets])
-
-    return gridCells
+        return cells
+    }, [activeWidget, widgets])
 }

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -1,21 +1,8 @@
 "use client"
 
-import type {ComponentType} from "react"
-import { bookmarkWidgetDefinition } from "@/components/widgets/BookmarkWidget"
-import { clockWidgetDefinition } from "@/components/widgets/ClockWidget"
-import { countdownWidgetDefinition } from "@/components/widgets/CountdownWidget"
-import { editorWidgetDefinition } from "@/components/widgets/EditorWidget"
-import { githubheatmapWidgetDefinition } from "@/components/widgets/GithubHeatmapWidget"
-import { githubWidgetDefinition } from "@/components/widgets/GithubWidget"
-import { kanbanWidgetDefinition } from "@/components/widgets/KanbanWidget"
-import { meetingsWidgetDefinition } from "@/components/widgets/MeetingsWidget"
-import { todoWidgetDefinition } from "@/components/widgets/TodoWidget"
-import { weatherWidgetDefinition } from "@/components/widgets/WeatherWidget"
-import { inboxWidgetDefinition } from "@/components/widgets/InboxWidget"
-import { cryptoWidgetDefinition } from "@/components/widgets/CryptoWidget"
-import { frameWidgetDefinition } from "@/components/widgets/FrameWidget"
+import React, { type ComponentType } from "react"
 
-export type TypedIntegration = "github" |"google" | "linear" | "atlassian" | string
+export type TypedIntegration = "github" | "google" | "linear" | "atlassian" | string
 
 export interface BaseWidget {
     id: string
@@ -77,25 +64,202 @@ export interface WidgetDefinition<Config = any, W extends BaseWidget = BaseWidge
     integration?: TypedIntegration
 }
 
+type WidgetDefinitionModule = Record<string, unknown>
+type WidgetDefinitionLoader = () => Promise<WidgetDefinitionModule>
+
+const pickDefinition = async (loader: WidgetDefinitionLoader): Promise<{ default: ComponentType<WidgetRuntimeProps> }> => {
+    const module = await loader()
+    const definition = Object.values(module).find((value): value is WidgetDefinition => {
+        return Boolean(value && typeof value === "object" && "Component" in value)
+    })
+
+    if (!definition) throw new Error("Widget module did not export a widget definition")
+
+    return { default: definition.Component as ComponentType<WidgetRuntimeProps> }
+}
+
+const createLazyWidgetDefinition = <Config = any>({
+    loader,
+    ...definition
+}: Omit<WidgetDefinition<Config>, "Component"> & { loader: WidgetDefinitionLoader }): WidgetDefinition<Config> => ({
+    ...definition,
+    Component: React.lazy(() => pickDefinition(loader)),
+})
 
 export const definitions: WidgetDefinition[] = [
-    bookmarkWidgetDefinition,
-    clockWidgetDefinition,
-    countdownWidgetDefinition,
-    cryptoWidgetDefinition,
-    editorWidgetDefinition,
-    frameWidgetDefinition,
-    githubheatmapWidgetDefinition,
-    githubWidgetDefinition,
-    inboxWidgetDefinition,
-    kanbanWidgetDefinition,
-    meetingsWidgetDefinition,
-    todoWidgetDefinition,
-    weatherWidgetDefinition
-] as const satisfies WidgetDefinition[]
+    createLazyWidgetDefinition({
+        name: "Bookmark",
+        description: "Store your bookmarks",
+        image: "/bookmark_preview.svg",
+        tags: ["productivity"],
+        sizes: {
+            desktop: { width: 1, height: 2 },
+            tablet: { width: 1, height: 2 },
+            mobile: { width: 1, height: 1 },
+        },
+        defaultConfig: { bookmarks: [] },
+        loader: () => import("@/components/widgets/BookmarkWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Clock",
+        description: "Beautiful clock to display your current time",
+        image: "/clock_preview.svg",
+        tags: ["productivity"],
+        sizes: {
+            desktop: { width: 1, height: 1 },
+            tablet: { width: 1, height: 1 },
+            mobile: { width: 1, height: 1 },
+        },
+        loader: () => import("@/components/widgets/ClockWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Countdown",
+        description: "See how much time is left to a special event",
+        image: "/countdown_preview.svg",
+        tags: [],
+        sizes: {
+            desktop: { width: 1, height: 1 },
+            tablet: { width: 1, height: 1 },
+            mobile: { width: 1, height: 2 },
+        },
+        defaultConfig: { countdown: null },
+        loader: () => import("@/components/widgets/CountdownWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Crypto",
+        description: "Track live crypto spot prices",
+        image: "/crypto_preview.svg",
+        tags: ["crypto", "finance"],
+        sizes: {
+            desktop: { width: 1, height: 2 },
+            tablet: { width: 1, height: 2 },
+            mobile: { width: 1, height: 2 },
+        },
+        defaultConfig: { timeframe: "24h", products: ["BTC-USD", "ETH-USD", "SOL-USD"] },
+        loader: () => import("@/components/widgets/CryptoWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Editor",
+        description: "A simple text editor widget",
+        image: "/editor_preview.svg",
+        tags: ["productivity"],
+        sizes: {
+            desktop: { width: 1, height: 2 },
+            tablet: { width: 1, height: 2 },
+            mobile: { width: 1, height: 2 },
+        },
+        defaultConfig: { notes: [] },
+        loader: () => import("@/components/widgets/EditorWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Frame",
+        description: "Embed content from any website using an iframe.",
+        image: "/frame_preview.svg",
+        tags: [],
+        sizes: {
+            desktop: { width: 2, height: 2 },
+            tablet: { width: 2, height: 2 },
+            mobile: { width: 1, height: 1 },
+        },
+        defaultConfig: { url: "" },
+        loader: () => import("@/components/widgets/FrameWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Github Heatmap",
+        integration: "github",
+        description: "Show off your commit streak.",
+        image: "/githubheatmap_preview.svg",
+        tags: ["github"],
+        sizes: {
+            desktop: { width: 2, height: 1 },
+            tablet: { width: 1, height: 1 },
+            mobile: { width: 1, height: 1 },
+        },
+        loader: () => import("@/components/widgets/GithubHeatmapWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Github",
+        integration: "github",
+        description: "See your open github issues & pull requests.",
+        image: "/github_preview.svg",
+        tags: ["github"],
+        sizes: {
+            desktop: { width: 1, height: 2 },
+            tablet: { width: 1, height: 2 },
+            mobile: { width: 1, height: 2 },
+        },
+        loader: () => import("@/components/widgets/GithubWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Inbox",
+        integration: "google",
+        description: "See your received google mails.",
+        image: "/inbox_preview.svg",
+        tags: ["productivity"],
+        sizes: {
+            desktop: { width: 1, height: 2 },
+            tablet: { width: 1, height: 2 },
+            mobile: { width: 1, height: 2 },
+        },
+        loader: () => import("@/components/widgets/InboxWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Kanban",
+        description: "Organize your tasks in a kanban board",
+        image: "/kanban_preview.svg",
+        tags: ["productivity"],
+        sizes: {
+            desktop: { width: 2, height: 2 },
+            tablet: { width: 2, height: 2 },
+            mobile: { width: 1, height: 2 },
+        },
+        defaultConfig: { columns: [] },
+        loader: () => import("@/components/widgets/KanbanWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Meetings",
+        integration: "google",
+        description: "Overview of your next meetings",
+        image: "/meetings_preview.svg",
+        tags: ["productivity"],
+        sizes: {
+            desktop: { width: 1, height: 2 },
+            tablet: { width: 1, height: 2 },
+            mobile: { width: 1, height: 2 },
+        },
+        loader: () => import("@/components/widgets/MeetingsWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Todo",
+        description: "All your tasks in one place",
+        image: "/todo_preview.svg",
+        tags: ["productivity"],
+        sizes: {
+            desktop: { width: 1, height: 2 },
+            tablet: { width: 1, height: 2 },
+            mobile: { width: 1, height: 1 },
+        },
+        defaultConfig: { todos: [] },
+        loader: () => import("@/components/widgets/TodoWidget"),
+    }),
+    createLazyWidgetDefinition({
+        name: "Weather",
+        description: "See the weather in your location",
+        image: "/weather_preview.svg",
+        tags: ["weather"],
+        sizes: {
+            desktop: { width: 1, height: 1 },
+            tablet: { width: 1, height: 1 },
+            mobile: { width: 1, height: 1 },
+        },
+        loader: () => import("@/components/widgets/WeatherWidget"),
+    }),
+]
+
+const definitionsByName = new Map(definitions.map((definition) => [definition.name, definition]))
 
 export const getWidgetDefinition = (name: string): WidgetDefinition => {
-    const def = definitions.find((w) => w.name === name)
+    const def = definitionsByName.get(name)
     if (!def) throw new Error(`Unknown widget type: ${name}`)
     return def
 }

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -75,6 +75,16 @@ export const deleteWidgetSchema = z.object({
     id: z.string(),
 })
 
+export const updateWidgetsLayoutSchema = z.object({
+    widgets: z.array(z.object({
+        id: z.string(),
+        height: z.number(),
+        width: z.number(),
+        positionX: z.number(),
+        positionY: z.number(),
+    })),
+})
+
 const providerEnum = z.enum(["google", "github", "notion"])
 
 export const deleteAccountSchema = z.object({


### PR DESCRIPTION
### Motivation
- Reduce redundant widget layout writes by sending only changed widgets to the server. 
- Improve performance and bundle size by lazy-loading widget components and by batching UI update work during drag-and-drop. 
- Scope integrations per-dashboard rendering and provide a context so components can reuse integration state without refetching. 

### Description
- Added a new API and DB helper to update multiple widget layouts in a single transaction via `updateWidgetsLayout` and a new `PATCH /api/widgets/layout` route with request validation (`updateWidgetsLayoutSchema`).
- Modified the widget-saving flow to compute dirty widgets and call `saveWidgetsLayout(dirtyWidgets)` from the dashboard, and updated `useWidgets` to support saving an array of widget updates and merging returned rows into the cache.
- Introduced `IntegrationsContext` and `IntegrationsProvider` in `useIntegrations`, allowing components to consume a scoped integrations value and avoid double-fetching; updated `Dashboard` to provide the integrations scope and `WidgetRenderer` to use per-widget `userId` when resolving integrations.
- Implemented several performance and code-quality changes: lazy-loading widget definitions in `lib/definitions.ts`, batching drag/drop position updates in `useDragAndDrop` using `requestAnimationFrame`, refactoring `useGrid` to memoized computation, and various small API/data fetching improvements (e.g. `getAccountsFromUser`, refactored account lookups).

### Testing
- Ran the TypeScript build with `pnpm build` and the project compiled successfully. 
- Executed the existing automated test suite with `pnpm test` and all tests passed. 
- Ran lint checks with `pnpm lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a056f9044b0832ca6ffdd6e40196cb5)